### PR TITLE
Support TF2, Python 3 and config switching off context embeddings

### DIFF
--- a/biaffine_ner_model.py
+++ b/biaffine_ner_model.py
@@ -3,7 +3,7 @@ from __future__ import division
 from __future__ import print_function
 
 import os,time,json,threading
-import random
+import random, io
 import numpy as np
 from collections import defaultdict
 #import tensorflow as tf
@@ -134,8 +134,8 @@ class BiaffineNERModel():
     if is_training:
       for sid, sent in enumerate(sentences):
         ner = {(s,e):self.ner_maps[t] for s,e,t in ners[sid]}
-        for s in xrange(len(sent)):
-          for e in xrange(s,len(sent)):
+        for s in range(len(sent)):
+          for e in range(s,len(sent)):
             gold_labels.append(ner.get((s,e),0))
     gold_labels = np.array(gold_labels)
 
@@ -250,11 +250,11 @@ class BiaffineNERModel():
   def get_pred_ner(self, sentences, span_scores, is_flat_ner):
     candidates = []
     for sid,sent in enumerate(sentences):
-      for s in xrange(len(sent)):
-        for e in xrange(s,len(sent)):
+      for s in range(len(sent)):
+        for e in range(s,len(sent)):
           candidates.append((sid,s,e))
 
-    top_spans = [[] for _ in xrange(len(sentences))]
+    top_spans = [[] for _ in range(len(sentences))]
     for i, type in enumerate(np.argmax(span_scores,axis=1)):
       if type > 0:
         sid, s,e = candidates[i]
@@ -262,7 +262,7 @@ class BiaffineNERModel():
 
 
     top_spans = [sorted(top_span,reverse=True,key=lambda x:x[3]) for top_span in top_spans]
-    sent_pred_mentions = [[] for _ in xrange(len(sentences))]
+    sent_pred_mentions = [[] for _ in range(len(sentences))]
     for sid, top_span in enumerate(top_spans):
       for ns,ne,t,_ in top_span:
         for ts,te,_ in sent_pred_mentions[sid]:
@@ -315,7 +315,7 @@ class BiaffineNERModel():
       fp += len(pred_ners - gold_ners)
 
       if is_final_test:
-        for i in xrange(self.num_types):
+        for i in range(self.num_types):
           sub_gm = set((sid,s,e) for sid,s,e,t in gold_ners if t ==i+1)
           sub_pm = set((sid,s,e) for sid,s,e,t in pred_ners if t == i+1)
           sub_tp[i] += len(sub_gm & sub_pm)

--- a/biaffine_ner_model.py
+++ b/biaffine_ner_model.py
@@ -331,9 +331,9 @@ class BiaffineNERModel():
 
     if is_final_test:
       print("****************SUB NER TYPES********************")
-      for i in xrange(self.num_types):
-        sub_r = 0 if sub_tp == 0 else float(sub_tp[i]) / (sub_tp[i] + sub_fn[i])
-        sub_p = 0 if sub_tp == 0 else float(sub_tp[i]) / (sub_tp[i] + sub_fp[i])
+      for i in range(self.num_types):
+        sub_r = 0 if sub_tp[i] == 0 else float(sub_tp[i]) / (sub_tp[i] + sub_fn[i])
+        sub_p = 0 if sub_tp[i] == 0 else float(sub_tp[i]) / (sub_tp[i] + sub_fp[i])
         sub_f1 = 0 if sub_p == 0 else 2.0 * sub_r * sub_p / (sub_r + sub_p)
 
         print("{} F1: {:.2f}%".format(self.ner_types[i],sub_f1 * 100))

--- a/biaffine_ner_model.py
+++ b/biaffine_ner_model.py
@@ -5,7 +5,11 @@ from __future__ import print_function
 import os,time,json,threading
 import random
 import numpy as np
-import tensorflow as tf
+from collections import defaultdict
+#import tensorflow as tf
+import tensorflow.compat.v1 as tf
+
+tf.compat.v1.disable_v2_behavior()
 import h5py
 
 import util
@@ -153,10 +157,14 @@ class BiaffineNERModel():
           cell_fw = util.CustomLSTMCell(self.config["contextualization_size"], num_sentences, lstm_dropout)
         with tf.variable_scope("bw_cell"):
           cell_bw = util.CustomLSTMCell(self.config["contextualization_size"], num_sentences, lstm_dropout)
-        state_fw = tf.contrib.rnn.LSTMStateTuple(tf.tile(cell_fw.initial_state.c, [num_sentences, 1]),
-                                                 tf.tile(cell_fw.initial_state.h, [num_sentences, 1]))
-        state_bw = tf.contrib.rnn.LSTMStateTuple(tf.tile(cell_bw.initial_state.c, [num_sentences, 1]),
-                                                 tf.tile(cell_bw.initial_state.h, [num_sentences, 1]))
+        state_fw = tf.compat.v1.nn.rnn_cell.LSTMStateTuple(
+          tf.tile(cell_fw.initial_state.c, [num_sentences, 1]),
+          tf.tile(cell_fw.initial_state.h, [num_sentences, 1]),
+        )
+        state_bw = tf.compat.v1.nn.rnn_cell.LSTMStateTuple(
+          tf.tile(cell_bw.initial_state.c, [num_sentences, 1]),
+          tf.tile(cell_bw.initial_state.h, [num_sentences, 1]),
+        )
 
         (fw_outputs, bw_outputs), ((_, fw_final_state), (_, bw_final_state)) = tf.nn.bidirectional_dynamic_rnn(
           cell_fw=cell_fw,

--- a/evaluate.py
+++ b/evaluate.py
@@ -4,7 +4,11 @@ from __future__ import division
 from __future__ import print_function
 
 
-import tensorflow as tf
+#import tensorflow as tf
+import tensorflow.compat.v1 as tf
+
+tf.compat.v1.disable_v2_behavior()
+
 import util,biaffine_ner_model
 
 if __name__ == "__main__":

--- a/experiments.conf
+++ b/experiments.conf
@@ -15,7 +15,10 @@ ft_es_300d {
   path = ../fasttext/cc.es.300.vec.filtered
   size = 300
 }
-
+w2v_cop_50d{
+  path = vec/coptic_50d.vec
+  size = 50
+}
 
 base  {
   ffnn_size = 150
@@ -145,3 +148,35 @@ ned_conll02 = ${base}{
   flat_ner = true
 }
 
+
+# Parameters for experiment using UD Coptic data
+cop = ${base}{
+  train_path = cop_train.jsonlines
+  lm_path = none
+  eval_path = cop_dev.jsonlines
+  test_path = cop_test.jsonlines
+  ner_types = ["thing"]
+  # comment out prev line and uncomment next to do 10-class classification instead of binary entity recognition
+  #ner_types = ["abstract","animal","object","event","place","organization","time","substance","plant","person"]
+  char_vocab_path = "char_vocab.cop.txt"
+  context_embeddings = ${w2v_cop_50d}
+  lm_size = 1
+  lm_layers = 1
+  flat_ner = false
+  contextualization_size = 40
+  contextualization_layers = 1
+
+  eval_frequency = 500
+  report_frequency = 200
+  log_root = logs
+  max_step = 8000
+  
+  lstm_dropout_rate = 0.1
+  lexical_dropout_rate = 0.1
+  dropout_rate = 0.1
+  learning_rate = 0.001
+  ffnn_size = 50
+  ffnn_depth = 2
+  char_embedding_size = 8
+
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tensorflow-gpu==1.12
+tensorflow>=2.2
 scikit-learn
 pyhocon
 numpy

--- a/train.py
+++ b/train.py
@@ -6,7 +6,10 @@ from __future__ import print_function
 import os
 import time
 
-import tensorflow as tf
+#import tensorflow as tf
+import tensorflow.compat.v1 as tf
+
+tf.compat.v1.disable_v2_behavior()
 import util,biaffine_ner_model
 
 if __name__ == "__main__":

--- a/util.py
+++ b/util.py
@@ -245,6 +245,8 @@ class EmbeddingDictionary(object):
       vocab_size = None
       with open(path) as f:
         for i, line in enumerate(f.readlines()):
+          if i == 0 and line.count(" ") == 1:  # header row
+            continue
           word_end = line.find(" ")
           word = line[:word_end]
           embedding = np.fromstring(line[word_end + 1:], np.float32, sep=" ")

--- a/util.py
+++ b/util.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import os
+import os, io
 import errno
 import codecs
 import collections
@@ -246,7 +246,7 @@ class EmbeddingDictionary(object):
     embedding_dict = collections.defaultdict(lambda:default_embedding)
     if len(path) > 0:
       vocab_size = None
-      with open(path) as f:
+      with io.open(path,encoding="utf8") as f:
         for i, line in enumerate(f.readlines()):
           if i == 0 and line.count(" ") == 1:  # header row
             continue
@@ -261,7 +261,8 @@ class EmbeddingDictionary(object):
     return embedding_dict
 
   def is_in_embeddings(self, key):
-    return self._embeddings.has_key(key)
+    return key in self._embeddings
+    #return self._embeddings.has_key(key)
 
   def __getitem__(self, key):
     embedding = self._embeddings[key]

--- a/util.py
+++ b/util.py
@@ -10,7 +10,10 @@ import shutil
 import sys
 
 import numpy as np
-import tensorflow as tf
+#import tensorflow as tf
+import tensorflow.compat.v1 as tf
+
+tf.compat.v1.disable_v2_behavior()
 import pyhocon
 
 def initialize_from_env():
@@ -273,7 +276,8 @@ class EmbeddingDictionary(object):
     else:
       return v
 
-class CustomLSTMCell(tf.contrib.rnn.RNNCell):
+# class CustomLSTMCell(tf.contrib.rnn.RNNCell):
+class CustomLSTMCell(tf.compat.v1.nn.rnn_cell.RNNCell):
   def __init__(self, num_units, batch_size, dropout):
     self._num_units = num_units
     self._dropout = dropout
@@ -281,11 +285,13 @@ class CustomLSTMCell(tf.contrib.rnn.RNNCell):
     self._initializer = self._block_orthonormal_initializer([self.output_size] * 3)
     initial_cell_state = tf.get_variable("lstm_initial_cell_state", [1, self.output_size])
     initial_hidden_state = tf.get_variable("lstm_initial_hidden_state", [1, self.output_size])
-    self._initial_state = tf.contrib.rnn.LSTMStateTuple(initial_cell_state, initial_hidden_state)
+    # self._initial_state = tf.contrib.rnn.LSTMStateTuple(initial_cell_state, initial_hidden_state)
+    self._initial_state = tf.compat.v1.nn.rnn_cell.LSTMStateTuple(initial_cell_state, initial_hidden_state)
 
   @property
   def state_size(self):
-    return tf.contrib.rnn.LSTMStateTuple(self.output_size, self.output_size)
+    #return tf.contrib.rnn.LSTMStateTuple(self.output_size, self.output_size)
+    return tf.compat.v1.nn.rnn_cell.LSTMStateTuple(self.output_size, self.output_size)
 
   @property
   def output_size(self):
@@ -305,7 +311,8 @@ class CustomLSTMCell(tf.contrib.rnn.RNNCell):
       i = tf.sigmoid(i)
       new_c = (1 - i) * c  + i * tf.tanh(j)
       new_h = tf.tanh(new_c) * tf.sigmoid(o)
-      new_state = tf.contrib.rnn.LSTMStateTuple(new_c, new_h)
+      #new_state = tf.contrib.rnn.LSTMStateTuple(new_c, new_h)
+      new_state = tf.compat.v1.nn.rnn_cell.LSTMStateTuple(new_c, new_h)
       return new_h, new_state
 
   def _orthonormal_initializer(self, scale=1.0):


### PR DESCRIPTION
  * Supports TF2.2 using `tf.compat.v1`
  * Use Python 3-compatible syntax
  * Use `lm_path = none` to switch off contextualized embeddings for low resource languages
  * Support word embeddings files with header row (vocab size, dimensionality in first row)
  * Bug fix in entity type breakdown in final eval report
